### PR TITLE
Dont fail entire build on wildcard unresolved

### DIFF
--- a/test/fixtures/wildcard-unresolved/actual.js
+++ b/test/fixtures/wildcard-unresolved/actual.js
@@ -1,0 +1,2 @@
+for (x of thing)
+	require(`unknown/${x}`);

--- a/test/fixtures/wildcard-unresolved/expected.js
+++ b/test/fixtures/wildcard-unresolved/expected.js
@@ -1,0 +1,10 @@
+var exports = {},
+    _dewExec = false;
+export function dew() {
+  if (_dewExec) return exports;
+  _dewExec = true;
+
+  for (x of thing) require(`unknown/${x}`);
+
+  return exports;
+}

--- a/transform-cjs-dew.js
+++ b/transform-cjs-dew.js
@@ -103,7 +103,7 @@ module.exports = function ({ types: t }) {
       depResolved = state.opts.resolve(depModule, { wildcard: true, optional });
 
       if (typeof depResolved === 'string' && depResolved.indexOf('*') !== -1)
-        throw new Error('Resolve of ' + depModule + ' did not handle wildcard, returned ' + JSON.stringify(depResolved));
+        return null;
 
       if (!depResolved)
         return nodeRequire(path, state, depModuleArg);
@@ -396,16 +396,20 @@ module.exports = function ({ types: t }) {
            */
           if (state.hasProcess) {
             let dep = addDependency(path, state, t.stringLiteral('process'));
-            path.unshiftContainer('body', t.variableDeclaration('var', [
-              t.variableDeclarator(t.identifier('process'), dep)
-            ]));
+            if (dep) {
+              path.unshiftContainer('body', t.variableDeclaration('var', [
+                t.variableDeclarator(t.identifier('process'), dep)
+              ]));
+            }
           }
 
           if (state.hasBuffer) {
             let dep = addDependency(path, state, t.stringLiteral('buffer'));
-            path.unshiftContainer('body', t.variableDeclaration('var', [
-              t.variableDeclarator(t.identifier('Buffer'), t.memberExpression(dep, t.identifier('Buffer')))
-            ]));
+            if (dep) {
+              path.unshiftContainer('body', t.variableDeclaration('var', [
+                t.variableDeclarator(t.identifier('Buffer'), t.memberExpression(dep, t.identifier('Buffer')))
+              ]));
+            }
           }
 
           /*
@@ -704,7 +708,10 @@ module.exports = function ({ types: t }) {
               );
             }
             else {
-              parentPath.replaceWith(addDependency(path, state, parentPath.node.arguments[0], isOptionalRequire(parentPath)));
+              const dep = addDependency(path, state, parentPath.node.arguments[0], isOptionalRequire(parentPath));
+              if (dep) {
+                parentPath.replaceWith(dep);
+              }
             }
           }
           else {


### PR DESCRIPTION
This fixes https://github.com/jspm/babel-plugin-transform-cjs-dew/issues/8 in ensuring that the build can still continue for unresolved wildcard cases at least giving some functionality.