### PR TITLE
globalThis global detection support

### DIFF
--- a/test/fixtures/debug/expected.js
+++ b/test/fixtures/debug/expected.js
@@ -2,7 +2,7 @@ import { dew as _msDew } from "ms";
 var exports = {},
     _dewExec = false;
 
-var _global = typeof self !== "undefined" ? self : global;
+var _global = typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : global;
 
 export function dew() {
   if (_dewExec) return exports;

--- a/test/fixtures/global-declared/expected.js
+++ b/test/fixtures/global-declared/expected.js
@@ -1,7 +1,7 @@
 var exports = {},
     _dewExec = false;
 
-var _global = typeof self !== "undefined" ? self : global;
+var _global = typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : global;
 
 export function dew() {
   var q;

--- a/test/fixtures/global-detect/expected.js
+++ b/test/fixtures/global-detect/expected.js
@@ -1,7 +1,7 @@
 var exports = {},
     _dewExec = false;
 
-var _global = typeof self !== "undefined" ? self : global;
+var _global = typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : global;
 
 export function dew() {
   var x;

--- a/test/fixtures/global-this-declared/actual.js
+++ b/test/fixtures/global-this-declared/actual.js
@@ -1,0 +1,1 @@
+var globalThis = 5;

--- a/test/fixtures/global-this-declared/expected.js
+++ b/test/fixtures/global-this-declared/expected.js
@@ -1,0 +1,8 @@
+var exports = {},
+    _dewExec = false;
+export function dew() {
+  if (_dewExec) return exports;
+  _dewExec = true;
+  var globalThis = 5;
+  return exports;
+}

--- a/test/fixtures/jquery/expected.js
+++ b/test/fixtures/jquery/expected.js
@@ -1,7 +1,7 @@
 var exports = {},
     _dewExec = false;
 
-var _global = typeof self !== "undefined" ? self : global;
+var _global = typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : global;
 
 export function dew() {
   if (_dewExec) return exports;

--- a/test/fixtures/scoped-globals/expected.js
+++ b/test/fixtures/scoped-globals/expected.js
@@ -1,7 +1,7 @@
 var exports = {},
     _dewExec = false;
 
-var _global = typeof self !== "undefined" ? self : global;
+var _global = typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : global;
 
 export function dew() {
   var asdf;

--- a/test/fixtures/self-declared/expected.js
+++ b/test/fixtures/self-declared/expected.js
@@ -1,7 +1,7 @@
 var exports = {},
     _dewExec = false;
 
-var _global = typeof self !== "undefined" ? self : global;
+var _global = typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : global;
 
 export function dew() {
   if (_dewExec) return exports;

--- a/test/fixtures/self-global-declared/expected.js
+++ b/test/fixtures/self-global-declared/expected.js
@@ -1,7 +1,7 @@
 var exports = {},
     _dewExec = false;
 
-var _global = typeof self !== "undefined" ? self : global;
+var _global = typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : global;
 
 export function dew() {
   var global;

--- a/test/fixtures/this-context/expected.js
+++ b/test/fixtures/this-context/expected.js
@@ -1,7 +1,7 @@
 var exports = {},
     _dewExec = false;
 
-var _global = typeof self !== "undefined" ? self : global;
+var _global = typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : global;
 
 export function dew() {
   if (_dewExec) return exports;

--- a/test/fixtures/this-nested-context/expected.js
+++ b/test/fixtures/this-nested-context/expected.js
@@ -1,7 +1,7 @@
 var exports = {},
     _dewExec = false;
 
-var _global = typeof self !== "undefined" ? self : global;
+var _global = typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : global;
 
 export function dew() {
   if (_dewExec) return exports;

--- a/test/fixtures/when/expected.js
+++ b/test/fixtures/when/expected.js
@@ -13,7 +13,7 @@ import { dew as _applyDew } from "./lib/apply";
 var exports = {},
     _dewExec = false;
 
-var _global = typeof self !== "undefined" ? self : global;
+var _global = typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : global;
 
 export function dew() {
   if (_dewExec) return exports;


### PR DESCRIPTION
This supports ensuring that `globalThis` is the first detected global in environment global detection.

Fixes https://github.com/jspm/babel-plugin-transform-cjs-dew/issues/10.