### PR TITLE
bug: add test case for process issue in chalk@2.4.2

### DIFF
--- a/test/fixtures/chalk/actual.js
+++ b/test/fixtures/chalk/actual.js
@@ -1,0 +1,2 @@
+// Example of a use of the "process" global that isn't picked up in chalk@2.4.2:
+const isSimpleWindowsTerm = process.platform === 'win32' && !(process.env.TERM || '').toLowerCase().startsWith('xterm');


### PR DESCRIPTION
If you use `process` in two children of a boolean expression (like
`<exp1> && <exp2>`) then it doesn't seem to be picked up by the plugin.
Removing either part of the expression in the test case results in `process`
being detected correctly.
