### PR TITLE
Node.js compatible ESM wrapper for CJS with cjs marker for distinguishing CJS transpiled to ESM

### DIFF
--- a/test/fixtures/requireesm-brand-nowrap/expected.js
+++ b/test/fixtures/requireesm-brand-nowrap/expected.js
@@ -18,3 +18,4 @@ const {
 } = _thing;
 readFileSync("asdf");
 export default {};
+export const __cjs = true;

--- a/test/fixtures/requireesm-brand-nowrap/options.js
+++ b/test/fixtures/requireesm-brand-nowrap/options.js
@@ -1,5 +1,6 @@
 module.exports = {
   nowrap: true,
+  cjsMarker: true,
   esmDependencies (x) {
     if (x === 'thing')
       return 'namespace';

--- a/test/fixtures/requireesm-brand/expected.js
+++ b/test/fixtures/requireesm-brand/expected.js
@@ -1,19 +1,19 @@
 import * as _nobinding2 from "nobinding";
-var _nobinding = _nobinding2;
-try {
-  if ("default" in _nobinding2) _nobinding = _nobinding2.default;
-} catch (e) {}
 import * as _fs2 from "fs";
-var _fs = _fs2;
-try {
-  if ("default" in _fs2) _fs = _fs2.default;
-} catch (e) {}
 import * as _thing from "thing";
 var exports = {},
   _dewExec = false;
 export function dew() {
   if (_dewExec) return exports;
   _dewExec = true;
+  var _nobinding = _nobinding2.__cjs ? _nobinding2.default : "default" in _nobinding2 && !_nobinding2.__esModule ? new Proxy(_nobinding2, {
+    get: (t, k, r) => k === "__esModule" || Reflect.get(t, k, r),
+    has: (t, k) => k === "__esModule" || Reflect.has(t, k)
+  }) : _nobinding2;
+  var _fs = _fs2.__cjs ? _fs2.default : "default" in _fs2 && !_fs2.__esModule ? new Proxy(_fs2, {
+    get: (t, k, r) => k === "__esModule" || Reflect.get(t, k, r),
+    has: (t, k) => k === "__esModule" || Reflect.has(t, k)
+  }) : _fs2;
   _nobinding;
   const {
     readFileSync


### PR DESCRIPTION
Work in progress to align with the new Node.js CJS to ESM interop.